### PR TITLE
fix: bump node

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -13,7 +13,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: docker-build
         run: |
-          echo "FROM alpine:3.16" > Dockerfile
+          echo "FROM alpine:3.19" > Dockerfile
           IFS=$'\n', LABELS=($(echo "$AIRFOCUS_INFRA_METADATA" | jq -r 'to_entries | map (["--label", .key, .value] | join("=")) | join("\n")'))
           docker build -t test ${LABELS[@]} .
         env:

--- a/action.yaml
+++ b/action.yaml
@@ -8,5 +8,5 @@ outputs:
   metadata:
     description: The metadata
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Bump node from 16 to 20 in gh-action node image as well as in alpine image